### PR TITLE
Fix for Windows and gradle scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+﻿.idea/**
+src/ghidra/Blackfyre/build/**
+src/ghidra/Blackfyre/dist
+src/ghidra/Blackfyre/lib
+src/ghidra/Blackfyre/.gradle/**
+src/ghidra/Blackfyre/.idea

--- a/src/ghidra/Blackfyre/build.gradle
+++ b/src/ghidra/Blackfyre/build.gradle
@@ -1,0 +1,65 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Builds a Ghidra Extension for a given Ghidra installation.
+//
+// An absolute path to the Ghidra installation directory must be supplied either by setting the 
+// GHIDRA_INSTALL_DIR environment variable or Gradle project property:
+//
+//     > export GHIDRA_INSTALL_DIR=<Absolute path to Ghidra> 
+//     > gradle
+//
+//         or
+//
+//     > gradle -PGHIDRA_INSTALL_DIR=<Absolute path to Ghidra>
+//
+// Gradle should be invoked from the directory of the project to build.  Please see the
+// application.gradle.version property in <GHIDRA_INSTALL_DIR>/Ghidra/application.properties
+// for the correction version of Gradle to use for the Ghidra installation you specify.
+
+//----------------------START "DO NOT MODIFY" SECTION------------------------------
+def ghidraInstallDir
+
+if (System.env.GHIDRA_INSTALL_DIR) {
+	ghidraInstallDir = System.env.GHIDRA_INSTALL_DIR
+}
+else if (project.hasProperty("GHIDRA_INSTALL_DIR")) {
+	ghidraInstallDir = project.getProperty("GHIDRA_INSTALL_DIR")
+}
+else {
+	throw new GradleException("Missing GHIDRA_INSTALL_DIR")
+}
+
+task distributeExtension {
+	group "Ghidra"
+
+	apply from: new File(ghidraInstallDir).getCanonicalPath() + "/support/buildExtension.gradle"
+	dependsOn ':buildExtension'
+}
+//----------------------END "DO NOT MODIFY" SECTION-------------------------------
+
+repositories {
+	mavenLocal()
+	mavenCentral()
+}
+
+dependencies {
+	implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '3.25.1'	
+}
+
+// Exclude additional files from the built extension
+// Ex: buildExtension.exclude '.idea/**'
+buildExtension.exclude '.idea/**'
+buildExtension.exclude 'examples/**'

--- a/src/ghidra/Blackfyre/extension.properties
+++ b/src/ghidra/Blackfyre/extension.properties
@@ -1,0 +1,5 @@
+name=Blackfyre
+description=Blackfyre is an open-source platform designed to standardize and streamline binary analysis. It provides tools and APIs for extracting, analyzing, and storing binary data in a disassembler-agnostic and architecture-agnostic format. This enables consistent workflows for advanced reverse engineering tasks powered by AI/ML, NLP, and LLMs.
+author=
+createdOn=
+version=@extversion@

--- a/src/ghidra/Blackfyre/src/main/java/blackfyre/datatypes/ghidra/GhidraPEBinaryContext.java
+++ b/src/ghidra/Blackfyre/src/main/java/blackfyre/datatypes/ghidra/GhidraPEBinaryContext.java
@@ -42,10 +42,15 @@ public class GhidraPEBinaryContext extends GhidraBinaryContext {
         
     protected void  initializeHeader() throws Exception
     {
-    	
     	File exePath = new File(theCurrentProgram.getExecutablePath());
         String path = exePath.getAbsolutePath();
-        FSRL fsrl = FSRL.fromString("file:/" + path);
+
+        // Windows default, if starts with a / then it is a linux system
+        String prefix = "file://";
+        if (path.startsWith("/")) {
+            prefix = "file:/";
+        }
+        FSRL fsrl = FSRL.fromString(prefix + path);
 
         FileByteProvider provider = new FileByteProvider(exePath, fsrl, java.nio.file.AccessMode.READ);
         


### PR DESCRIPTION
- Ensure that the start of the FSRL is file:// even on Windows 
- Add gradle scripts for building Ghidra plugin
  -  Should be able to build now using gradle -DGHIDRA_INSTALL_DIR=<GHIDRA_INSTALL> or if you have the proper environment variable set up 
- Update .gitignore